### PR TITLE
Delegate null seems to be due to the deployment not being started first.

### DIFF
--- a/src/main/java/net/redpipe/swagger/SwaggerUIPlugin.java
+++ b/src/main/java/net/redpipe/swagger/SwaggerUIPlugin.java
@@ -9,6 +9,7 @@ public class SwaggerUIPlugin extends Plugin {
 
     @Override
     public Single<Void> deployToResteasy(VertxResteasyDeployment deployment) {
+        deployment.start();
         deployment.getRegistry().addPerInstanceResource(SwaggerUIController.class);
         return Single.just(null);
     }


### PR DESCRIPTION
This should give you a successful build with warnings.  
I looked at Julien's examples and it appears that the registry delegate is not available before calling the start() method.

https://github.com/vert-x3/vertx-examples/blob/64d2baebb88c274e18d16fe31ea1ca60c939e250/resteasy-examples/src/main/java/io/vertx/examples/resteasy/helloworld/Server.java#L23